### PR TITLE
Deprecate CRTP, use regular polymorphism

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,91 @@
+Language:        Cpp
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: false
+ColumnLimit:     80
+CommentPragmas:  ''
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+IncludeCategories:
+  - Regex:           'ginn'
+    Priority:        1
+  - Regex:           '\.'
+    Priority:        2
+IndentCaseLabels: false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        2
+UseTab:          Never
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Executables, dSYM
+*.out
+*.out.*

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ CXX=g++
 .PHONY: all
 all: test demo
 
-test: test.cpp meanwhile.h
-	${CXX} -std=c++14 -pthread -g -I./ -I./extern test.cpp -o test
+test: test.cpp meanwhile/meanwhile.h
+	${CXX} -std=c++17 -pthread -g -I./ -I./extern test.cpp -o test.out
 
-demo: demo.cpp meanwhile.h
-	${CXX} -std=c++14 -pthread -I./ demo.cpp -o demo
+demo: demo.cpp meanwhile/meanwhile.h
+	${CXX} -std=c++17 -pthread -O3 -I./ demo.cpp -o demo.out
 
 .PHONY: install
 install:
@@ -15,4 +15,4 @@ install:
 
 .PHONY: clean
 clean:
-	rm -rf test demo
+	rm -rf *.out.*

--- a/demo.cpp
+++ b/demo.cpp
@@ -38,10 +38,13 @@ int main(int argc, char** argv) {
     }
     c.done();
   }
-  
+
   for (auto speed : {Speed::None, Speed::Overall, Speed::Last, Speed::Both}) {
     unsigned long long work{677};
-    auto c = Counter(work).message("Decreasing").unit_of_speed("").speed(Speed::Overall);
+    auto c = Counter(work)
+                 .message("Decreasing")
+                 .unit_of_speed("")
+                 .speed(Speed::Overall);
     c.start();
     while (work > 0) {
       std::this_thread::sleep_for(13ms);

--- a/demo.cpp
+++ b/demo.cpp
@@ -2,14 +2,14 @@
 
 #include <atomic>
 #include <iostream>
-#include "meanwhile.h"
+#include <meanwhile/meanwhile.h>
 
 int main(int argc, char** argv) {
   using namespace std::chrono_literals;
   using namespace mew;
 
   for (auto sty : {Ellipsis, Bar, Moon, Square}) {
-    auto anim = Animation().message("Working").style(sty);
+    auto anim = Animation().message("Working").style(sty).interval(0.5s);
     anim.start();
     std::this_thread::sleep_for(10s);
     anim.done();
@@ -37,6 +37,17 @@ int main(int argc, char** argv) {
       work += 0.213;
     }
     c.done();
+  }
+  
+  for (auto speed : {Speed::None, Speed::Overall, Speed::Last, Speed::Both}) {
+    unsigned long long work{677};
+    auto c = Counter(work).message("Decreasing").unit_of_speed("").speed(Speed::Overall);
+    c.start();
+    while (work > 0) {
+      std::this_thread::sleep_for(13ms);
+      work--;
+    }
+    // Let destructor do the c.done() this time
   }
 
   for (auto speed : {Speed::None, Speed::Overall, Speed::Last, Speed::Both}) {

--- a/meanwhile/meanwhile.h
+++ b/meanwhile/meanwhile.h
@@ -194,7 +194,7 @@ class AsyncDisplay {
   void interval(double pd) { interval_ = Duration(pd); }
   void no_tty() { no_tty_ = true; }
 
- friend class Composite;
+  friend class Composite;
 };
 
 // Class: Animation
@@ -272,7 +272,6 @@ class Animation : public AsyncDisplay {
   }
 };
 
-
 // Class: Composite
 // Creates a composite display out of two display that shows them side by side.
 // For instance, you can combine two <Counter>s to monitor two variables.
@@ -287,7 +286,9 @@ class Composite : public AsyncDisplay {
     return len + 1;
   }
 
-  Duration default_interval_() const override { return left_->default_interval_(); }
+  Duration default_interval_() const override {
+    return left_->default_interval_();
+  }
 
  public:
   Composite(std::unique_ptr<AsyncDisplay> left,
@@ -299,9 +300,7 @@ class Composite : public AsyncDisplay {
       throw std::runtime_error("Running displays cannot be composed!");
     }
     AsyncDisplay::interval(min(left_->interval_, right_->interval_));
-    if (left_->no_tty_ or right_->no_tty_) {
-      AsyncDisplay::no_tty();
-    }
+    if (left_->no_tty_ or right_->no_tty_) { AsyncDisplay::no_tty(); }
   }
   ~Composite() { done(); }
 
@@ -318,7 +317,7 @@ class Composite : public AsyncDisplay {
 template <typename LeftDisplay, typename RightDisplay>
 auto operator|(LeftDisplay left, RightDisplay right) {
   return Composite(std::make_unique<LeftDisplay>(left),
-                                              std::make_unique<RightDisplay>(right));
+                   std::make_unique<RightDisplay>(right));
 }
 
 // Trait class to extract underlying value type from numerics and
@@ -337,14 +336,9 @@ template <typename T>
 using value_t = typename AtomicTraits<T>::value_type;
 
 template <typename T>
-using signed_t =
-        typename std::conditional_t
-        <
-            std::is_integral_v<T>,
-            std::make_signed<T>,
-            std::common_type<T>
-        >::type;
-
+using signed_t = typename std::conditional_t<std::is_integral_v<T>,
+                                             std::make_signed<T>,
+                                             std::common_type<T>>::type;
 
 // Class: Speedometer
 // Helper class to measure and display speed of progress.
@@ -376,8 +370,10 @@ class Speedometer {
       using ValueType = value_t<Progress>;
       using SignedType = signed_t<ValueType>;
 
-      auto speed = double(SignedType(progress_) - SignedType(first_progress_)) / dur.count();
-      auto speed2 = double(SignedType(progress_) - SignedType(last_progress_)) / dur2.count();
+      auto speed = double(SignedType(progress_) - SignedType(first_progress_)) /
+                   dur.count();
+      auto speed2 = double(SignedType(progress_) - SignedType(last_progress_)) /
+                    dur2.count();
 
       ss << std::fixed << std::setprecision(2) << "(";
       if (speed_ == Speed::Overall or speed_ == Speed::Both) { ss << speed; }
@@ -424,7 +420,6 @@ class Speedometer {
   Speedometer(Progress& progress) : progress_(progress) {}
 };
 
-
 // Class: Counter
 // Monitors and displays a single numeric variable
 template <typename Progress = size_t>
@@ -468,9 +463,7 @@ class Counter : public AsyncDisplay {
   //   progress - Variable to be monitored and displayed
   //   out      - Output stream to write to
   Counter(Progress& progress, std::ostream& out = std::cout)
-      : AsyncDisplay(out),
-        progress_(progress),
-        speedom_(progress) {}
+      : AsyncDisplay(out), progress_(progress), speedom_(progress) {}
 
   Counter(const Counter<Progress>& other)
       : AsyncDisplay(other),
@@ -531,10 +524,11 @@ class ProgressBar : public AsyncDisplay {
   using ValueType = value_t<Progress>;
 
   Speedometer<Progress> speedom_;
-  Progress& progress_;                    // work done so far
-  static constexpr ValueType width_ = 30; // width of progress bar (TODO: make customizable?)
-  ValueType total_{100};                  // total work
-  bool counts_ = true;                    // whether to display counts
+  Progress& progress_; // work done so far
+  static constexpr ValueType width_ =
+      30;                // width of progress bar (TODO: make customizable?)
+  ValueType total_{100}; // total work
+  bool counts_ = true;   // whether to display counts
 
   Strings partials_; // progress bar display strings
 
@@ -542,9 +536,11 @@ class ProgressBar : public AsyncDisplay {
   // Compute the shape of the progress bar based on progress and write to output
   // stream.
   size_t render_progress_bar_(std::ostream& out) {
-    ValueType on = width_ * progress_ / total_;
-    ValueType partial =
-        partials_.size() * width_ * progress_ / total_ - partials_.size() * on;
+    ValueType progress_copy =
+        progress_; // to avoid progress_ changing during computations below
+    ValueType on = width_ * progress_copy / total_;
+    ValueType partial = partials_.size() * width_ * progress_copy / total_ -
+                        partials_.size() * on;
     if (on >= width_) {
       on = width_;
       partial = 0;
@@ -686,7 +682,6 @@ class ProgressBar : public AsyncDisplay {
     return *this;
   }
 };
-
 
 } // namespace mew
 

--- a/meanwhile/meanwhile.h
+++ b/meanwhile/meanwhile.h
@@ -67,7 +67,7 @@ enum class Speed : unsigned short { None, Last, Overall, Both };
 // Class: AsyncDisplay
 // Base class to handle asynchronous displays.
 class AsyncDisplay {
- protected:
+ private:
   Duration interval_{0.0};
   std::unique_ptr<std::thread> displayer_;
   std::condition_variable completion_;

--- a/test.cpp
+++ b/test.cpp
@@ -10,7 +10,7 @@
 #include <tuple>
 #include <vector>
 #include <catch.hpp>
-#include <meanwhile.h>
+#include <meanwhile/meanwhile.h>
 
 using namespace std::chrono_literals;
 using namespace mew;
@@ -71,7 +71,7 @@ using ProgressTypeList =
 TEMPLATE_LIST_TEST_CASE("Counter constant", "[counter]", ProgressTypeList) {
   std::stringstream out;
 
-  using ValueType = typename ProgressTraits<TestType>::value_type;
+  using ValueType = value_t<TestType>;
 
   TestType amount{GENERATE(as<ValueType>(), 0, 3)};
   auto sp = GENERATE(Speed::None, Speed::Last);
@@ -127,7 +127,7 @@ auto extract_counts(const std::string& prefix,
 TEMPLATE_LIST_TEST_CASE("Counter", "[counter]", ProgressTypeList) {
   std::stringstream out;
 
-  using ValueType = typename ProgressTraits<TestType>::value_type;
+  using ValueType = value_t<TestType>;
 
   TestType amount{GENERATE(as<ValueType>(), 0, 3)};
   ValueType initial = amount;
@@ -169,27 +169,27 @@ template <typename Display>
 Display factory_helper();
 
 template <>
-Animation factory_helper<>() {
+Animation factory_helper<Animation>() {
   static std::stringstream hide;
   return Animation(hide);
 }
 
 template <>
-CounterDisplay<> factory_helper<>() {
+Counter<> factory_helper<Counter<>>() {
   static size_t progress;
   static std::stringstream hide;
   return Counter(progress, hide);
 }
 
 template <>
-ProgressBarDisplay<float> factory_helper<>() {
+ProgressBar<float> factory_helper<ProgressBar<float>>() {
   static float progress;
   static std::stringstream hide;
   return ProgressBar(progress, hide);
 }
 
 using DisplayTypeList =
-    std::tuple<Animation, CounterDisplay<>, ProgressBarDisplay<float>>;
+    std::tuple<Animation, Counter<>, ProgressBar<float>>;
 
 TEMPLATE_LIST_TEST_CASE("Error cases", "[edges]", DisplayTypeList) {
   auto orig = factory_helper<TestType>();

--- a/test.cpp
+++ b/test.cpp
@@ -92,7 +92,7 @@ TEMPLATE_LIST_TEST_CASE("Counter constant", "[counter]", ProgressTypeList) {
   auto parts = check_and_get_parts(out.str());
 
   std::stringstream ss;
-  if (std::is_floating_point<TestType>::value) {
+  if (std::is_floating_point_v<TestType>) {
     ss << std::fixed << std::setprecision(2);
   }
   ss << amount;
@@ -157,7 +157,7 @@ TEMPLATE_LIST_TEST_CASE("Counter", "[counter]", ProgressTypeList) {
 
   // Final result should always be displayed
   ValueType expected = initial;
-  if (std::is_floating_point<ValueType>::value) {
+  if (std::is_floating_point_v<ValueType>) {
     expected += ValueType(121.2);
   } else {
     expected += ValueType(101);
@@ -188,8 +188,7 @@ ProgressBar<float> factory_helper<ProgressBar<float>>() {
   return ProgressBar(progress, hide);
 }
 
-using DisplayTypeList =
-    std::tuple<Animation, Counter<>, ProgressBar<float>>;
+using DisplayTypeList = std::tuple<Animation, Counter<>, ProgressBar<float>>;
 
 TEMPLATE_LIST_TEST_CASE("Error cases", "[edges]", DisplayTypeList) {
   auto orig = factory_helper<TestType>();
@@ -289,7 +288,11 @@ TEST_CASE("Composite bar-counter", "[composite]") {
   std::stringstream out;
 
   std::atomic<size_t> sents{0}, toks{0};
-  auto bar = ProgressBar(sents, out).total(505).message("Sents").style(Bars).interval(0.01) |
+  auto bar = ProgressBar(sents, out)
+                 .total(505)
+                 .message("Sents")
+                 .style(Bars)
+                 .interval(0.01) |
              Counter(toks, out).message("Toks").unit_of_speed("tok/s").speed(
                  Speed::Last);
   bar.start();


### PR DESCRIPTION
Conditionally determining the display type based on argparse is a real use case. Having all of them use the same base type makes this type of use much less awkward.